### PR TITLE
Add WingPanel WinUI app with shared services and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,83 @@
-hey
+# WingPanel
+
+WingPanel is a WinUI 3 packaged shell companion that surfaces quick access launchers, task switching, volume controls and notifications in a single, keyboard accessible panel. The solution is organised into three projects:
+
+- **WingPanel.App** – the WinUI 3 packaged front-end that renders the interactive panel and hosts region controls.
+- **WingPanel.Core** – cross-platform services, settings models, P/Invoke wrappers and logging infrastructure shared by the app and tests.
+- **WingPanel.Tests** – xUnit based unit tests targeting the core library.
+
+## Prerequisites
+
+To build and debug the app you need a Windows 11 machine with the following tools installed:
+
+1. [.NET SDK 8.0](https://dotnet.microsoft.com/download).
+2. Visual Studio 2022 17.8 or later with the **Universal Windows Platform development** and **.NET desktop development** workloads.
+3. The WinUI 3 workload for the .NET SDK:
+   ```bash
+   dotnet workload install winui
+   ```
+4. Windows App SDK runtime dependencies (installed automatically with the Visual Studio workload).
+
+> **Note:** The WinUI 3 packaging project targets `net8.0-windows10.0.19041.0`, so building on non-Windows hosts is not supported.
+
+## Building the solution
+
+### From Visual Studio
+
+1. Open `WingPanel.sln`.
+2. When prompted, restore NuGet packages.
+3. Set **WingPanel.App** as the startup project.
+4. Choose the desired architecture (x64/x86/arm64) and configuration (Debug/Release).
+5. Build with `Build > Build Solution`.
+
+### From the command line
+
+```bash
+# Restore dependencies
+msbuild WingPanel.sln -t:Restore
+
+# Build the packaged app (Debug configuration)
+msbuild WingPanel.sln -p:Configuration=Debug
+
+# Run unit tests
+dotnet test src/WingPanel.Tests/WingPanel.Tests.csproj
+```
+
+Because the packaged project produces an MSIX, the build output is generated under `src/WingPanel.App/bin/<Configuration>/<Architecture>/`. The MSIX bundle can be installed by double-clicking the generated package or via `Add-AppxPackage` in PowerShell.
+
+## Packaging and deployment
+
+To produce a signed MSIX package ready for sideloading:
+
+1. Ensure you have a valid code signing certificate (.pfx). For local testing you can create one with the Windows SDK `makecert`/`New-SelfSignedCertificate` tools.
+2. In Visual Studio right-click **WingPanel.App** and choose **Publish > Create App Packages...**. Follow the wizard to select sideloading, certificate and output location.
+3. Alternatively, from the command line run:
+   ```bash
+   msbuild src/WingPanel.App/WingPanel.App.csproj -p:Configuration=Release -p:GenerateAppInstallerFile=false -p:UapAppxPackageBuildMode=StoreUpload
+   ```
+4. Install the produced MSIX by double-clicking it or using:
+   ```powershell
+   Add-AppxPackage .\WingPanel.App_1.0.0.0_x64.msixbundle
+   ```
+
+## Debugging
+
+- **Visual Studio:** set breakpoints in the WinUI project, press `F5` to launch the packaged app. The `PanelWindow` will appear docked near the top of the primary monitor. Keyboard navigation (arrow keys) and drag-and-drop can be inspected live.
+- **Logging:** runtime logs are written to `%LocalAppData%\WingPanel\Logs`. Each day creates a new `wingpanel-YYYYMMDD.log` file. This is useful when debugging hotkey registration or settings persistence.
+- **Settings:** user settings are stored at `%LocalAppData%\WingPanel\Settings.json`. Delete the file to reset defaults or edit it while the app is closed to tweak configuration.
+- **Unit tests:** run `dotnet test src/WingPanel.Tests/WingPanel.Tests.csproj` to verify settings migration, hotkey fallback logic and MRU tracking behaviour.
+
+## Project structure
+
+```
+WingPanel.sln
+├── src
+│   ├── WingPanel.App          # WinUI 3 packaged application
+│   ├── WingPanel.Core         # Shared services, models and logging
+│   └── WingPanel.Tests        # xUnit test project targeting the core library
+└── README.md
+```
+
+## Contributing
+
+Issues and pull requests are welcome. Please ensure new code paths include appropriate unit tests and keep the solution building on supported Windows configurations.

--- a/WingPanel.sln
+++ b/WingPanel.sln
@@ -1,0 +1,33 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.8.34330.188
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WingPanel.App", "src\\WingPanel.App\\WingPanel.App.csproj", "{910504D4-352C-419F-A711-A4956C7DB207}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WingPanel.Core", "src\\WingPanel.Core\\WingPanel.Core.csproj", "{310C3900-EFBA-4FD1-96F2-913D7DB24C5A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WingPanel.Tests", "src\\WingPanel.Tests\\WingPanel.Tests.csproj", "{7E03C937-9786-416F-A56C-E84E4734A7B1}"
+EndProject
+Global
+  GlobalSection(SolutionConfigurationPlatforms) = preSolution
+    Debug|Any CPU = Debug|Any CPU
+    Release|Any CPU = Release|Any CPU
+  EndGlobalSection
+  GlobalSection(ProjectConfigurationPlatforms) = postSolution
+    {910504D4-352C-419F-A711-A4956C7DB207}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+    {910504D4-352C-419F-A711-A4956C7DB207}.Debug|Any CPU.Build.0 = Debug|Any CPU
+    {910504D4-352C-419F-A711-A4956C7DB207}.Release|Any CPU.ActiveCfg = Release|Any CPU
+    {910504D4-352C-419F-A711-A4956C7DB207}.Release|Any CPU.Build.0 = Release|Any CPU
+    {310C3900-EFBA-4FD1-96F2-913D7DB24C5A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+    {310C3900-EFBA-4FD1-96F2-913D7DB24C5A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+    {310C3900-EFBA-4FD1-96F2-913D7DB24C5A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+    {310C3900-EFBA-4FD1-96F2-913D7DB24C5A}.Release|Any CPU.Build.0 = Release|Any CPU
+    {7E03C937-9786-416F-A56C-E84E4734A7B1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+    {7E03C937-9786-416F-A56C-E84E4734A7B1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+    {7E03C937-9786-416F-A56C-E84E4734A7B1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+    {7E03C937-9786-416F-A56C-E84E4734A7B1}.Release|Any CPU.Build.0 = Release|Any CPU
+  EndGlobalSection
+  GlobalSection(SolutionProperties) = preSolution
+    HideSolutionNode = FALSE
+  EndGlobalSection
+EndGlobal

--- a/src/WingPanel.App/App.xaml
+++ b/src/WingPanel.App/App.xaml
@@ -1,0 +1,15 @@
+<Application
+    x:Class="WingPanel.App.App"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls="using:Microsoft.UI.Xaml.Controls">
+    <Application.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <controls:XamlControlsResources />
+                <ResourceDictionary Source="Resources/Styles/Styles.xaml" />
+                <ResourceDictionary Source="Resources/Themes/Colors.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </Application.Resources>
+</Application>

--- a/src/WingPanel.App/App.xaml.cs
+++ b/src/WingPanel.App/App.xaml.cs
@@ -1,0 +1,29 @@
+using Microsoft.UI.Xaml;
+using WingPanel.App.Services;
+
+namespace WingPanel.App;
+
+public partial class App : Application
+{
+    private readonly ServiceBootstrapper _services;
+    private PanelWindow? _window;
+
+    public App()
+    {
+        InitializeComponent();
+        _services = new ServiceBootstrapper();
+        UnhandledException += OnUnhandledException;
+    }
+
+    protected override void OnLaunched(LaunchActivatedEventArgs args)
+    {
+        _window ??= new PanelWindow(_services);
+        _window.Activate();
+    }
+
+    private void OnUnhandledException(object sender, UnhandledExceptionEventArgs e)
+    {
+        _services.Logger.LogError("Unhandled exception", e.Exception);
+        e.Handled = true;
+    }
+}

--- a/src/WingPanel.App/PanelWindow.xaml
+++ b/src/WingPanel.App/PanelWindow.xaml
@@ -1,0 +1,40 @@
+<Window
+    x:Class="WingPanel.App.PanelWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:vm="using:WingPanel.App.ViewModels"
+    Title="WingPanel">
+    <Window.Resources>
+        <DataTemplate x:Key="RegionTemplate" x:DataType="vm:RegionHostViewModel">
+            <ContentControl Content="{x:Bind View}" HorizontalContentAlignment="Stretch" VerticalContentAlignment="Stretch" />
+        </DataTemplate>
+        <ItemsPanelTemplate x:Key="HorizontalPanelTemplate">
+            <StackPanel Orientation="Horizontal" />
+        </ItemsPanelTemplate>
+    </Window.Resources>
+    <Grid>
+        <ListView
+            x:Name="RegionList"
+            ItemsSource="{x:Bind ViewModel.Regions, Mode=OneWay}"
+            ItemTemplate="{StaticResource RegionTemplate}"
+            ItemsPanel="{StaticResource HorizontalPanelTemplate}"
+            SelectionMode="None"
+            CanDragItems="True"
+            AllowDrop="True"
+            CanReorderItems="True">
+            <ListView.KeyboardNavigationMode>Cycle</ListView.KeyboardNavigationMode>
+            <ListView.ItemContainerStyle>
+                <Style TargetType="ListViewItem">
+                    <Setter Property="Margin" Value="0,0,4,0" />
+                    <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                </Style>
+            </ListView.ItemContainerStyle>
+            <ListView.ItemContainerTransitions>
+                <TransitionCollection>
+                    <EntranceThemeTransition />
+                    <ReorderThemeTransition />
+                </TransitionCollection>
+            </ListView.ItemContainerTransitions>
+        </ListView>
+    </Grid>
+</Window>

--- a/src/WingPanel.App/PanelWindow.xaml.cs
+++ b/src/WingPanel.App/PanelWindow.xaml.cs
@@ -1,0 +1,95 @@
+using System;
+using Microsoft.UI.Windowing;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
+using WingPanel.App.Services;
+using WingPanel.App.ViewModels;
+using WingPanel.Core.Models;
+using Windows.Graphics;
+using Windows.System;
+
+namespace WingPanel.App;
+
+public sealed partial class PanelWindow : Window
+{
+    private readonly ServiceBootstrapper _services;
+    private AppWindow? _appWindow;
+
+    public PanelWindow(ServiceBootstrapper services)
+    {
+        InitializeComponent();
+        _services = services;
+        ViewModel = new PanelWindowViewModel(services);
+        DataContext = ViewModel;
+
+        RegionList.DragItemsCompleted += OnDragItemsCompleted;
+        RegionList.PreviewKeyDown += OnRegionListPreviewKeyDown;
+        _services.DisplayBounds.DisplayChanged += OnDisplayChanged;
+
+        UpdateWindowBounds(_services.DisplayBounds.GetPrimaryDisplay());
+    }
+
+    public PanelWindowViewModel ViewModel { get; }
+
+    private async void OnDragItemsCompleted(ListViewBase sender, DragItemsCompletedEventArgs args)
+    {
+        await ViewModel.CommitRegionOrderAsync().ConfigureAwait(false);
+    }
+
+    private void OnDisplayChanged(object? sender, DisplayBounds bounds)
+    {
+        DispatcherQueue.TryEnqueue(() => UpdateWindowBounds(bounds));
+    }
+
+    private void UpdateWindowBounds(DisplayBounds bounds)
+    {
+        EnsureAppWindow();
+        if (_appWindow is null)
+        {
+            return;
+        }
+
+        var width = Math.Min(bounds.Width, 1200);
+        var height = Math.Min(bounds.Height / 2, 480);
+        var x = bounds.X + (bounds.Width - width) / 2;
+        var y = bounds.Y + 20;
+        _appWindow.MoveAndResize(new RectInt32(x, y, width, height));
+    }
+
+    private void EnsureAppWindow()
+    {
+        if (_appWindow is not null)
+        {
+            return;
+        }
+
+        var handle = WinRT.Interop.WindowNative.GetWindowHandle(this);
+        var windowId = WinRT.Interop.Win32Interop.GetWindowIdFromWindow(handle);
+        _appWindow = AppWindow.GetFromWindowId(windowId);
+    }
+
+    private void OnRegionListPreviewKeyDown(object sender, KeyRoutedEventArgs e)
+    {
+        if (e.Key is VirtualKey.Left or VirtualKey.Right)
+        {
+            var list = (ListView)sender;
+            var direction = e.Key == VirtualKey.Left ? -1 : 1;
+            if (list.SelectedIndex < 0 && list.Items.Count > 0)
+            {
+                list.SelectedIndex = 0;
+                return;
+            }
+
+            var target = Math.Clamp(list.SelectedIndex + direction, 0, list.Items.Count - 1);
+            list.SelectedIndex = target;
+            list.ScrollIntoView(list.SelectedItem, ScrollIntoViewAlignment.Leading);
+            e.Handled = true;
+        }
+        else if (e.Key == VirtualKey.Escape)
+        {
+            Close();
+            e.Handled = true;
+        }
+    }
+}

--- a/src/WingPanel.App/Program.cs
+++ b/src/WingPanel.App/Program.cs
@@ -1,0 +1,13 @@
+using System;
+using Microsoft.UI.Xaml;
+
+namespace WingPanel.App;
+
+public static class Program
+{
+    [STAThread]
+    public static void Main(string[] args)
+    {
+        Application.Start(_ => new App());
+    }
+}

--- a/src/WingPanel.App/Resources/Styles/Styles.xaml
+++ b/src/WingPanel.App/Resources/Styles/Styles.xaml
@@ -1,0 +1,21 @@
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Style x:Key="RegionHeaderTextStyle" TargetType="TextBlock">
+        <Setter Property="FontSize" Value="18" />
+        <Setter Property="FontWeight" Value="SemiBold" />
+        <Setter Property="Margin" Value="0,0,0,4" />
+        <Setter Property="Foreground" Value="{StaticResource PanelForegroundBrush}" />
+    </Style>
+    <Style TargetType="ListView">
+        <Setter Property="IsTabStop" Value="False" />
+        <Setter Property="HorizontalAlignment" Value="Stretch" />
+        <Setter Property="MinHeight" Value="120" />
+    </Style>
+    <Style TargetType="Button">
+        <Setter Property="Background" Value="{StaticResource PanelAccentBrush}" />
+        <Setter Property="Foreground" Value="White" />
+        <Setter Property="CornerRadius" Value="4" />
+        <Setter Property="Padding" Value="12,6" />
+    </Style>
+</ResourceDictionary>

--- a/src/WingPanel.App/Resources/Themes/Colors.xaml
+++ b/src/WingPanel.App/Resources/Themes/Colors.xaml
@@ -1,0 +1,8 @@
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Color x:Key="PanelAccentColor">#FF4CAF50</Color>
+    <SolidColorBrush x:Key="PanelAccentBrush" Color="{StaticResource PanelAccentColor}" />
+    <SolidColorBrush x:Key="ApplicationPageBackgroundThemeBrush" Color="#FF1F1F1F" />
+    <SolidColorBrush x:Key="PanelForegroundBrush" Color="#FFFFFFFF" />
+</ResourceDictionary>

--- a/src/WingPanel.App/Services/ServiceBootstrapper.cs
+++ b/src/WingPanel.App/Services/ServiceBootstrapper.cs
@@ -1,0 +1,36 @@
+using WingPanel.Core.Logging;
+using WingPanel.Core.Services.Implementations;
+using WingPanel.Core.Services.Interfaces;
+
+namespace WingPanel.App.Services;
+
+public sealed class ServiceBootstrapper
+{
+    public ServiceBootstrapper()
+    {
+        Logger = new LogService();
+        Settings = new SettingsService(Logger);
+        Hotkeys = new HotkeyService(logger: Logger);
+        Cursor = new CursorService();
+        DisplayBounds = new DisplayBoundsService();
+        Audio = new AudioService();
+        Windows = new WindowEnumService();
+        ActionCenter = new ActionCenterService();
+    }
+
+    public ILogService Logger { get; }
+
+    public ISettingsService Settings { get; }
+
+    public IHotkeyService Hotkeys { get; }
+
+    public ICursorService Cursor { get; }
+
+    public IDisplayBoundsService DisplayBounds { get; }
+
+    public IAudioService Audio { get; }
+
+    public IWindowEnumService Windows { get; }
+
+    public IActionCenterService ActionCenter { get; }
+}

--- a/src/WingPanel.App/ViewModels/ObservableObject.cs
+++ b/src/WingPanel.App/ViewModels/ObservableObject.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace WingPanel.App.ViewModels;
+
+public abstract class ObservableObject : INotifyPropertyChanged
+{
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    protected bool SetProperty<T>(ref T storage, T value, [CallerMemberName] string? propertyName = null)
+    {
+        if (EqualityComparer<T>.Default.Equals(storage, value))
+        {
+            return false;
+        }
+
+        storage = value;
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        return true;
+    }
+}

--- a/src/WingPanel.App/ViewModels/PanelWindowViewModel.cs
+++ b/src/WingPanel.App/ViewModels/PanelWindowViewModel.cs
@@ -1,0 +1,78 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading.Tasks;
+using WingPanel.App.Services;
+using WingPanel.App.Views.Regions;
+using WingPanel.Core.Models.Settings;
+
+namespace WingPanel.App.ViewModels;
+
+public sealed class PanelWindowViewModel
+{
+    private readonly ServiceBootstrapper _services;
+    private readonly Dictionary<string, RegionHostViewModel> _regionMap;
+
+    public PanelWindowViewModel(ServiceBootstrapper services)
+    {
+        _services = services;
+        _regionMap = CreateRegionMap();
+        Regions = new ObservableCollection<RegionHostViewModel>();
+
+        foreach (var region in _regionMap.Values)
+        {
+            region.Initialize(_services);
+        }
+
+        ApplyLayout(_services.Settings.Current.Layout.OrderedRegions);
+        _services.Settings.SettingsChanged += OnSettingsChanged;
+        _services.Hotkeys.Reset();
+        _services.Hotkeys.TryRegister("PanelToggle", _services.Settings.Current.ToggleHotkey);
+    }
+
+    public ObservableCollection<RegionHostViewModel> Regions { get; }
+
+    private Dictionary<string, RegionHostViewModel> CreateRegionMap()
+    {
+        return new Dictionary<string, RegionHostViewModel>
+        {
+            [RegionNames.Launcher] = new RegionHostViewModel(RegionNames.Launcher, "Launcher", new LauncherRegion()),
+            [RegionNames.TaskSwitcher] = new RegionHostViewModel(RegionNames.TaskSwitcher, "Tasks", new TaskSwitcherRegion()),
+            [RegionNames.Volume] = new RegionHostViewModel(RegionNames.Volume, "Volume", new VolumeRegion()),
+            [RegionNames.Notifications] = new RegionHostViewModel(RegionNames.Notifications, "Notifications", new NotificationsRegion())
+        };
+    }
+
+    private void ApplyLayout(IEnumerable<string> order)
+    {
+        var seen = new HashSet<string>();
+        Regions.Clear();
+        foreach (var id in order)
+        {
+            if (_regionMap.TryGetValue(id, out var region) && seen.Add(id))
+            {
+                Regions.Add(region);
+            }
+        }
+
+        foreach (var kvp in _regionMap)
+        {
+            if (seen.Add(kvp.Key))
+            {
+                Regions.Add(kvp.Value);
+            }
+        }
+    }
+
+    private async void OnSettingsChanged(object? sender, WingPanel.Core.Models.Settings.WingPanelSettings settings)
+    {
+        ApplyLayout(settings.Layout.OrderedRegions);
+        await CommitRegionOrderAsync().ConfigureAwait(false);
+    }
+
+    public async Task CommitRegionOrderAsync()
+    {
+        _services.Settings.Current.Layout.OrderedRegions = Regions.Select(r => r.Id).ToList();
+        await _services.Settings.SaveAsync().ConfigureAwait(false);
+    }
+}

--- a/src/WingPanel.App/ViewModels/RegionHostViewModel.cs
+++ b/src/WingPanel.App/ViewModels/RegionHostViewModel.cs
@@ -1,0 +1,29 @@
+using Microsoft.UI.Xaml.Controls;
+using WingPanel.App.Services;
+using WingPanel.App.Views.Regions;
+
+namespace WingPanel.App.ViewModels;
+
+public sealed class RegionHostViewModel
+{
+    public RegionHostViewModel(string id, string displayName, UserControl view)
+    {
+        Id = id;
+        DisplayName = displayName;
+        View = view;
+    }
+
+    public string Id { get; }
+
+    public string DisplayName { get; }
+
+    public UserControl View { get; }
+
+    public void Initialize(ServiceBootstrapper services)
+    {
+        if (View is IRegionControl regionControl)
+        {
+            regionControl.Initialize(services);
+        }
+    }
+}

--- a/src/WingPanel.App/ViewModels/Regions/LauncherRegionViewModel.cs
+++ b/src/WingPanel.App/ViewModels/Regions/LauncherRegionViewModel.cs
@@ -1,0 +1,53 @@
+using System.Collections.ObjectModel;
+using WingPanel.Core.Models.Settings;
+using WingPanel.Core.Services.Interfaces;
+
+namespace WingPanel.App.ViewModels.Regions;
+
+public sealed class LauncherRegionViewModel : ObservableObject
+{
+    private readonly ISettingsService _settings;
+    private readonly ILogService _logger;
+    private string _title = "Launcher";
+
+    public LauncherRegionViewModel(ISettingsService settings, ILogService logger)
+    {
+        _settings = settings;
+        _logger = logger;
+        FrequentApps = new ObservableCollection<string>();
+        ApplySettings(settings.Current);
+        _settings.SettingsChanged += OnSettingsChanged;
+    }
+
+    public ObservableCollection<string> FrequentApps { get; }
+
+    public string Title
+    {
+        get => _title;
+        set => SetProperty(ref _title, value);
+    }
+
+    private void OnSettingsChanged(object? sender, WingPanelSettings settings)
+    {
+        ApplySettings(settings);
+    }
+
+    private void ApplySettings(WingPanelSettings settings)
+    {
+        FrequentApps.Clear();
+        if (settings.Launcher.ShowFrequentApps)
+        {
+            for (var i = 1; i <= settings.Launcher.MaxFrequentApps; i++)
+            {
+                FrequentApps.Add($"Frequent app {i}");
+            }
+            Title = "Frequent apps";
+        }
+        else
+        {
+            Title = "Launcher";
+        }
+
+        _logger.LogInformation($"Launcher region refreshed with {FrequentApps.Count} items");
+    }
+}

--- a/src/WingPanel.App/ViewModels/Regions/NotificationsRegionViewModel.cs
+++ b/src/WingPanel.App/ViewModels/Regions/NotificationsRegionViewModel.cs
@@ -1,0 +1,62 @@
+using System.Collections.ObjectModel;
+using WingPanel.Core.Models.Settings;
+using WingPanel.Core.Services.Interfaces;
+
+namespace WingPanel.App.ViewModels.Regions;
+
+public sealed class NotificationsRegionViewModel : ObservableObject
+{
+    private readonly IActionCenterService _actionCenter;
+    private readonly ISettingsService _settings;
+    private bool _isActionCenterVisible;
+    private bool _doNotDisturb;
+
+    public NotificationsRegionViewModel(IActionCenterService actionCenter, ISettingsService settings)
+    {
+        _actionCenter = actionCenter;
+        _settings = settings;
+        Notifications = new ObservableCollection<string>();
+        _doNotDisturb = settings.Current.Notifications.EnableDoNotDisturb;
+        _actionCenter.VisibilityChanged += OnVisibilityChanged;
+        _settings.SettingsChanged += OnSettingsChanged;
+        GeneratePlaceholder();
+    }
+
+    public ObservableCollection<string> Notifications { get; }
+
+    public bool IsActionCenterVisible
+    {
+        get => _isActionCenterVisible;
+        set => SetProperty(ref _isActionCenterVisible, value);
+    }
+
+    public bool DoNotDisturb
+    {
+        get => _doNotDisturb;
+        set
+        {
+            if (SetProperty(ref _doNotDisturb, value))
+            {
+                _settings.Current.Notifications.EnableDoNotDisturb = value;
+            }
+        }
+    }
+
+    public void ToggleActionCenter() => _actionCenter.Toggle();
+
+    private void OnVisibilityChanged(object? sender, bool visible)
+    {
+        IsActionCenterVisible = visible;
+    }
+
+    private void OnSettingsChanged(object? sender, WingPanelSettings settings)
+    {
+        DoNotDisturb = settings.Notifications.EnableDoNotDisturb;
+    }
+
+    private void GeneratePlaceholder()
+    {
+        Notifications.Clear();
+        Notifications.Add("No notifications");
+    }
+}

--- a/src/WingPanel.App/ViewModels/Regions/TaskSwitcherRegionViewModel.cs
+++ b/src/WingPanel.App/ViewModels/Regions/TaskSwitcherRegionViewModel.cs
@@ -1,0 +1,63 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using WingPanel.Core.Models;
+using WingPanel.Core.Services.Interfaces;
+
+namespace WingPanel.App.ViewModels.Regions;
+
+public sealed class TaskSwitcherRegionViewModel : ObservableObject
+{
+    private readonly IWindowEnumService _windowService;
+    private WindowInfo? _selected;
+
+    public TaskSwitcherRegionViewModel(IWindowEnumService windowService)
+    {
+        _windowService = windowService;
+        Windows = new ObservableCollection<WindowInfo>(windowService.CurrentWindows);
+        if (Windows.Count > 0)
+        {
+            SelectedWindow = Windows[0];
+        }
+
+        _windowService.WindowsChanged += OnWindowsChanged;
+    }
+
+    public ObservableCollection<WindowInfo> Windows { get; }
+
+    public WindowInfo? SelectedWindow
+    {
+        get => _selected;
+        set => SetProperty(ref _selected, value);
+    }
+
+    public void MoveSelection(int delta)
+    {
+        if (Windows.Count == 0)
+        {
+            return;
+        }
+
+        var currentIndex = SelectedWindow is null ? 0 : Windows.IndexOf(SelectedWindow);
+        var targetIndex = (currentIndex + delta + Windows.Count) % Windows.Count;
+        SelectedWindow = Windows[targetIndex];
+        _windowService.NotifyActivated(SelectedWindow);
+    }
+
+    private void OnWindowsChanged(object? sender, IReadOnlyList<WindowInfo> windows)
+    {
+        Windows.Clear();
+        foreach (var window in windows)
+        {
+            Windows.Add(window);
+        }
+
+        if (Windows.Count > 0)
+        {
+            SelectedWindow = Windows[0];
+        }
+        else
+        {
+            SelectedWindow = null;
+        }
+    }
+}

--- a/src/WingPanel.App/ViewModels/Regions/VolumeRegionViewModel.cs
+++ b/src/WingPanel.App/ViewModels/Regions/VolumeRegionViewModel.cs
@@ -1,0 +1,61 @@
+using WingPanel.Core.Services.Interfaces;
+
+namespace WingPanel.App.ViewModels.Regions;
+
+public sealed class VolumeRegionViewModel : ObservableObject
+{
+    private readonly IAudioService _audioService;
+    private double _volume;
+    private bool _isMuted;
+    private bool _updating;
+
+    public VolumeRegionViewModel(IAudioService audioService)
+    {
+        _audioService = audioService;
+        _volume = _audioService.Volume * 100d;
+        _isMuted = _audioService.IsMuted;
+        _audioService.VolumeChanged += OnVolumeChanged;
+        _audioService.MutedChanged += OnMutedChanged;
+    }
+
+    public double Volume
+    {
+        get => _volume;
+        set
+        {
+            if (SetProperty(ref _volume, value) && !_updating)
+            {
+                _audioService.SetVolume(value / 100d);
+            }
+        }
+    }
+
+    public bool IsMuted
+    {
+        get => _isMuted;
+        set
+        {
+            if (SetProperty(ref _isMuted, value) && !_updating)
+            {
+                if (value != _audioService.IsMuted)
+                {
+                    _audioService.ToggleMute();
+                }
+            }
+        }
+    }
+
+    private void OnVolumeChanged(object? sender, double volume)
+    {
+        _updating = true;
+        Volume = volume * 100d;
+        _updating = false;
+    }
+
+    private void OnMutedChanged(object? sender, bool isMuted)
+    {
+        _updating = true;
+        IsMuted = isMuted;
+        _updating = false;
+    }
+}

--- a/src/WingPanel.App/Views/Regions/IRegionControl.cs
+++ b/src/WingPanel.App/Views/Regions/IRegionControl.cs
@@ -1,0 +1,8 @@
+using WingPanel.App.Services;
+
+namespace WingPanel.App.Views.Regions;
+
+public interface IRegionControl
+{
+    void Initialize(ServiceBootstrapper services);
+}

--- a/src/WingPanel.App/Views/Regions/LauncherRegion.xaml
+++ b/src/WingPanel.App/Views/Regions/LauncherRegion.xaml
@@ -1,0 +1,26 @@
+<UserControl
+    x:Class="WingPanel.App.Views.Regions.LauncherRegion"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    x:Name="Root"
+    x:DefaultBindMode="OneWay">
+    <Grid>
+        <StackPanel Spacing="4">
+            <TextBlock Text="{x:Bind ViewModel.Title}" Style="{StaticResource RegionHeaderTextStyle}" />
+            <ListView
+                ItemsSource="{x:Bind ViewModel.FrequentApps}"
+                SelectionMode="None"
+                IsItemClickEnabled="True"
+                ItemClick="LauncherList_ItemClick">
+                <ListView.ItemTemplate>
+                    <DataTemplate x:DataType="x:String">
+                        <StackPanel Orientation="Horizontal" Spacing="8">
+                            <FontIcon Glyph="&#xE8B7;" />
+                            <TextBlock Text="{x:Bind}" />
+                        </StackPanel>
+                    </DataTemplate>
+                </ListView.ItemTemplate>
+            </ListView>
+        </StackPanel>
+    </Grid>
+</UserControl>

--- a/src/WingPanel.App/Views/Regions/LauncherRegion.xaml.cs
+++ b/src/WingPanel.App/Views/Regions/LauncherRegion.xaml.cs
@@ -1,0 +1,38 @@
+using Microsoft.UI.Xaml.Controls;
+using WingPanel.App.Services;
+using WingPanel.App.ViewModels.Regions;
+
+namespace WingPanel.App.Views.Regions;
+
+public sealed partial class LauncherRegion : UserControl, IRegionControl
+{
+    private ServiceBootstrapper? _services;
+
+    public LauncherRegion()
+    {
+        InitializeComponent();
+    }
+
+    public LauncherRegionViewModel ViewModel { get; private set; } = null!;
+
+    public void Initialize(ServiceBootstrapper services)
+    {
+        _services = services;
+        ViewModel = new LauncherRegionViewModel(services.Settings, services.Logger);
+        DataContext = ViewModel;
+        Bindings.Update();
+    }
+
+    private void LauncherList_ItemClick(object sender, ItemClickEventArgs e)
+    {
+        if (_services is null)
+        {
+            return;
+        }
+
+        if (e.ClickedItem is string app)
+        {
+            _services.Logger.LogInformation($"Launcher invoked {app}");
+        }
+    }
+}

--- a/src/WingPanel.App/Views/Regions/NotificationsRegion.xaml
+++ b/src/WingPanel.App/Views/Regions/NotificationsRegion.xaml
@@ -1,0 +1,22 @@
+<UserControl
+    x:Class="WingPanel.App.Views.Regions.NotificationsRegion"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    x:DefaultBindMode="OneWay">
+    <Grid>
+        <StackPanel Spacing="8">
+            <TextBlock Text="Notifications" Style="{StaticResource RegionHeaderTextStyle}" />
+            <ToggleSwitch
+                Header="Do not disturb"
+                IsOn="{x:Bind ViewModel.DoNotDisturb, Mode=TwoWay}" />
+            <Button Content="Toggle action center" Click="OnToggleActionCenter" />
+            <ListView ItemsSource="{x:Bind ViewModel.Notifications}" SelectionMode="None">
+                <ListView.ItemTemplate>
+                    <DataTemplate x:DataType="x:String">
+                        <TextBlock Text="{x:Bind}" />
+                    </DataTemplate>
+                </ListView.ItemTemplate>
+            </ListView>
+        </StackPanel>
+    </Grid>
+</UserControl>

--- a/src/WingPanel.App/Views/Regions/NotificationsRegion.xaml.cs
+++ b/src/WingPanel.App/Views/Regions/NotificationsRegion.xaml.cs
@@ -1,0 +1,28 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using WingPanel.App.Services;
+using WingPanel.App.ViewModels.Regions;
+
+namespace WingPanel.App.Views.Regions;
+
+public sealed partial class NotificationsRegion : UserControl, IRegionControl
+{
+    public NotificationsRegion()
+    {
+        InitializeComponent();
+    }
+
+    public NotificationsRegionViewModel ViewModel { get; private set; } = null!;
+
+    public void Initialize(ServiceBootstrapper services)
+    {
+        ViewModel = new NotificationsRegionViewModel(services.ActionCenter, services.Settings);
+        DataContext = ViewModel;
+        Bindings.Update();
+    }
+
+    private void OnToggleActionCenter(object sender, RoutedEventArgs e)
+    {
+        ViewModel?.ToggleActionCenter();
+    }
+}

--- a/src/WingPanel.App/Views/Regions/TaskSwitcherRegion.xaml
+++ b/src/WingPanel.App/Views/Regions/TaskSwitcherRegion.xaml
@@ -1,0 +1,30 @@
+<UserControl
+    x:Class="WingPanel.App.Views.Regions.TaskSwitcherRegion"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:core="using:WingPanel.Core.Models"
+    x:DefaultBindMode="OneWay">
+    <Grid>
+        <StackPanel Spacing="8">
+            <TextBlock Text="Task switcher" Style="{StaticResource RegionHeaderTextStyle}" />
+            <ListView
+                x:Name="WindowList"
+                ItemsSource="{x:Bind ViewModel.Windows}"
+                SelectedItem="{x:Bind ViewModel.SelectedWindow, Mode=TwoWay}"
+                SelectionMode="Single">
+                <ListView.ItemTemplate>
+                    <DataTemplate x:DataType="core:WindowInfo">
+                        <StackPanel Orientation="Horizontal" Spacing="8">
+                            <FontIcon Glyph="&#xE737;" />
+                            <TextBlock Text="{x:Bind Title}" />
+                        </StackPanel>
+                    </DataTemplate>
+                </ListView.ItemTemplate>
+            </ListView>
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Spacing="8">
+                <Button Content="Prev" Click="OnPrevClicked" />
+                <Button Content="Next" Click="OnNextClicked" />
+            </StackPanel>
+        </StackPanel>
+    </Grid>
+</UserControl>

--- a/src/WingPanel.App/Views/Regions/TaskSwitcherRegion.xaml.cs
+++ b/src/WingPanel.App/Views/Regions/TaskSwitcherRegion.xaml.cs
@@ -1,0 +1,32 @@
+using Microsoft.UI.Xaml.Controls;
+using WingPanel.App.Services;
+using WingPanel.App.ViewModels.Regions;
+
+namespace WingPanel.App.Views.Regions;
+
+public sealed partial class TaskSwitcherRegion : UserControl, IRegionControl
+{
+    public TaskSwitcherRegion()
+    {
+        InitializeComponent();
+    }
+
+    public TaskSwitcherRegionViewModel ViewModel { get; private set; } = null!;
+
+    public void Initialize(ServiceBootstrapper services)
+    {
+        ViewModel = new TaskSwitcherRegionViewModel(services.Windows);
+        DataContext = ViewModel;
+        Bindings.Update();
+    }
+
+    private void OnPrevClicked(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
+    {
+        ViewModel?.MoveSelection(-1);
+    }
+
+    private void OnNextClicked(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
+    {
+        ViewModel?.MoveSelection(1);
+    }
+}

--- a/src/WingPanel.App/Views/Regions/VolumeRegion.xaml
+++ b/src/WingPanel.App/Views/Regions/VolumeRegion.xaml
@@ -1,0 +1,17 @@
+<UserControl
+    x:Class="WingPanel.App.Views.Regions.VolumeRegion"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    x:Name="Root"
+    x:DefaultBindMode="OneWay">
+    <Grid>
+        <StackPanel Spacing="8">
+            <TextBlock Text="Volume" Style="{StaticResource RegionHeaderTextStyle}" />
+            <Slider Minimum="0" Maximum="100" Value="{x:Bind ViewModel.Volume, Mode=TwoWay}" />
+            <ToggleSwitch
+                OnContent="Muted"
+                OffContent="Sound on"
+                IsOn="{x:Bind ViewModel.IsMuted, Mode=TwoWay}" />
+        </StackPanel>
+    </Grid>
+</UserControl>

--- a/src/WingPanel.App/Views/Regions/VolumeRegion.xaml.cs
+++ b/src/WingPanel.App/Views/Regions/VolumeRegion.xaml.cs
@@ -1,0 +1,22 @@
+using Microsoft.UI.Xaml.Controls;
+using WingPanel.App.Services;
+using WingPanel.App.ViewModels.Regions;
+
+namespace WingPanel.App.Views.Regions;
+
+public sealed partial class VolumeRegion : UserControl, IRegionControl
+{
+    public VolumeRegion()
+    {
+        InitializeComponent();
+    }
+
+    public VolumeRegionViewModel ViewModel { get; private set; } = null!;
+
+    public void Initialize(ServiceBootstrapper services)
+    {
+        ViewModel = new VolumeRegionViewModel(services.Audio);
+        DataContext = ViewModel;
+        Bindings.Update();
+    }
+}

--- a/src/WingPanel.App/WingPanel.App.csproj
+++ b/src/WingPanel.App/WingPanel.App.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
+    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
+    <RootNamespace>WingPanel.App</RootNamespace>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+    <Platforms>x86;x64;arm64</Platforms>
+    <UseWinUI>true</UseWinUI>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.5.240331000" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.756" />
+    <PackageReference Include="CommunityToolkit.WinUI" Version="8.1.2309.0" />
+    <PackageReference Include="CommunityToolkit.WinUI.UI.Controls" Version="8.1.2309.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\\WingPanel.Core\\WingPanel.Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/WingPanel.App/app.manifest
+++ b/src/WingPanel.App/app.manifest
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="WingPanel.App" />
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+      <requestedPrivileges>
+        <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware>
+    </windowsSettings>
+  </application>
+</assembly>

--- a/src/WingPanel.Core/Interop/User32.cs
+++ b/src/WingPanel.Core/Interop/User32.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+
+namespace WingPanel.Core.Interop;
+
+[SupportedOSPlatform("windows")]
+internal static partial class User32
+{
+    [StructLayout(LayoutKind.Sequential)]
+    public struct POINT
+    {
+        public int X;
+        public int Y;
+    }
+
+    [LibraryImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static partial bool GetCursorPos(out POINT point);
+
+    [LibraryImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static partial bool SetCursorPos(int x, int y);
+
+    [LibraryImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static partial bool RegisterHotKey(nint hWnd, int id, uint fsModifiers, uint vk);
+
+    [LibraryImport("user32.dll")]
+    public static partial void UnregisterHotKey(nint hWnd, int id);
+
+    [LibraryImport("user32.dll")]
+    public static partial int GetSystemMetrics(int nIndex);
+
+    public const int SM_CXSCREEN = 0;
+    public const int SM_CYSCREEN = 1;
+}

--- a/src/WingPanel.Core/Logging/LogService.cs
+++ b/src/WingPanel.Core/Logging/LogService.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Globalization;
+using System.IO;
+using Microsoft.Extensions.Logging;
+using WingPanel.Core.Services.Interfaces;
+
+namespace WingPanel.Core.Logging;
+
+public sealed class LogService : ILogService, IDisposable
+{
+    private readonly object _sync = new();
+    private readonly string _logDirectory;
+    private StreamWriter? _writer;
+    private DateTime _currentDate;
+
+    public LogService(string? baseDirectory = null)
+    {
+        var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        _logDirectory = baseDirectory ?? Path.Combine(localAppData, "WingPanel", "Logs");
+        Directory.CreateDirectory(_logDirectory);
+        EnsureWriter();
+    }
+
+    public void Log(LogLevel level, string message, Exception? exception = null)
+    {
+        EnsureWriter();
+        var line = string.Format(CultureInfo.InvariantCulture, "{0:o} [{1}] {2}", DateTime.UtcNow, level, message);
+        lock (_sync)
+        {
+            _writer?.WriteLine(line);
+            if (exception is not null)
+            {
+                _writer?.WriteLine(exception);
+            }
+        }
+    }
+
+    private void EnsureWriter()
+    {
+        var today = DateTime.UtcNow.Date;
+        lock (_sync)
+        {
+            if (_writer is not null && today == _currentDate)
+            {
+                return;
+            }
+
+            _writer?.Dispose();
+            _currentDate = today;
+            var file = Path.Combine(_logDirectory, $"wingpanel-{today:yyyyMMdd}.log");
+            _writer = new StreamWriter(new FileStream(file, FileMode.Append, FileAccess.Write, FileShare.ReadWrite))
+            {
+                AutoFlush = true
+            };
+        }
+    }
+
+    public void Dispose()
+    {
+        lock (_sync)
+        {
+            _writer?.Dispose();
+            _writer = null;
+        }
+    }
+}

--- a/src/WingPanel.Core/Models/DisplayBounds.cs
+++ b/src/WingPanel.Core/Models/DisplayBounds.cs
@@ -1,0 +1,10 @@
+namespace WingPanel.Core.Models;
+
+public readonly record struct DisplayBounds(int X, int Y, int Width, int Height)
+{
+    public static DisplayBounds Default { get; } = new(0, 0, 1920, 1080);
+
+    public int Right => X + Width;
+
+    public int Bottom => Y + Height;
+}

--- a/src/WingPanel.Core/Models/HotkeyBinding.cs
+++ b/src/WingPanel.Core/Models/HotkeyBinding.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Text.Json.Serialization;
+
+namespace WingPanel.Core.Models;
+
+[Flags]
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum HotkeyModifiers
+{
+    None = 0,
+    Control = 1,
+    Shift = 2,
+    Alt = 4,
+    Win = 8
+}
+
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum VirtualKey
+{
+    None = 0,
+    A = 0x41,
+    C = 0x43,
+    V = 0x56,
+    Space = 0x20,
+    Escape = 0x1B,
+    Tab = 0x09,
+    Left = 0x25,
+    Right = 0x27,
+    Up = 0x26,
+    Down = 0x28,
+    Enter = 0x0D
+}
+
+public readonly record struct HotkeyBinding(HotkeyModifiers Modifiers, VirtualKey Key)
+{
+    public static HotkeyBinding WinSpace { get; } = new(HotkeyModifiers.Win, VirtualKey.Space);
+
+    public bool IsEmpty => Modifiers == HotkeyModifiers.None && Key == VirtualKey.None;
+
+    public HotkeyBinding WithModifiers(HotkeyModifiers modifiers) => new(modifiers, Key);
+
+    public HotkeyBinding WithAdditionalModifier(HotkeyModifiers modifier)
+        => new(Modifiers | modifier, Key);
+
+    public override string ToString() => $"{Modifiers}+{Key}";
+}
+
+public sealed class HotkeyEventArgs : EventArgs
+{
+    public HotkeyEventArgs(string name, HotkeyBinding binding)
+    {
+        Name = name;
+        Binding = binding;
+    }
+
+    public string Name { get; }
+
+    public HotkeyBinding Binding { get; }
+}

--- a/src/WingPanel.Core/Models/PixelPoint.cs
+++ b/src/WingPanel.Core/Models/PixelPoint.cs
@@ -1,0 +1,6 @@
+namespace WingPanel.Core.Models;
+
+public readonly record struct PixelPoint(int X, int Y)
+{
+    public static PixelPoint Empty { get; } = new(0, 0);
+}

--- a/src/WingPanel.Core/Models/Settings/WingPanelSettings.cs
+++ b/src/WingPanel.Core/Models/Settings/WingPanelSettings.cs
@@ -1,0 +1,77 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace WingPanel.Core.Models.Settings;
+
+using WingPanel.Core.Models;
+
+public class WingPanelSettings
+{
+    public const int CurrentVersion = 2;
+
+    public int Version { get; set; } = CurrentVersion;
+
+    public HotkeyBinding ToggleHotkey { get; set; } = HotkeyBinding.WinSpace;
+
+    public LauncherSettings Launcher { get; set; } = new();
+
+    public VolumeSettings Volume { get; set; } = new();
+
+    public TaskSwitcherSettings TaskSwitcher { get; set; } = new();
+
+    public NotificationSettings Notifications { get; set; } = new();
+
+    public RegionLayoutSettings Layout { get; set; } = RegionLayoutSettings.CreateDefault();
+
+    [JsonExtensionData]
+    public Dictionary<string, object?> ExtensionData { get; set; } = new();
+}
+
+public class LauncherSettings
+{
+    public bool ShowFrequentApps { get; set; } = true;
+
+    public int MaxFrequentApps { get; set; } = 6;
+}
+
+public class VolumeSettings
+{
+    public bool ShowDeviceSwitcher { get; set; } = true;
+
+    public bool UseHardwareButtons { get; set; } = true;
+}
+
+public class TaskSwitcherSettings
+{
+    public bool ShowDesktopPreview { get; set; } = true;
+
+    public bool IncludeMinimizedWindows { get; set; } = true;
+}
+
+public class NotificationSettings
+{
+    public bool ShowBadges { get; set; } = true;
+
+    public bool EnableDoNotDisturb { get; set; } = false;
+}
+
+public class RegionLayoutSettings
+{
+    public List<string> OrderedRegions { get; set; } = new()
+    {
+        RegionNames.Launcher,
+        RegionNames.TaskSwitcher,
+        RegionNames.Volume,
+        RegionNames.Notifications
+    };
+
+    public static RegionLayoutSettings CreateDefault() => new();
+}
+
+public static class RegionNames
+{
+    public const string Launcher = "Launcher";
+    public const string Volume = "Volume";
+    public const string TaskSwitcher = "TaskSwitcher";
+    public const string Notifications = "Notifications";
+}

--- a/src/WingPanel.Core/Models/WindowInfo.cs
+++ b/src/WingPanel.Core/Models/WindowInfo.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace WingPanel.Core.Models;
+
+public sealed record WindowInfo(nint Handle, string Title, bool IsVisible)
+{
+    public DateTime LastActivatedUtc { get; init; } = DateTime.UtcNow;
+
+    public WindowInfo WithActivatedNow() => this with { LastActivatedUtc = DateTime.UtcNow };
+}

--- a/src/WingPanel.Core/Services/Implementations/ActionCenterService.cs
+++ b/src/WingPanel.Core/Services/Implementations/ActionCenterService.cs
@@ -1,0 +1,43 @@
+using System;
+using WingPanel.Core.Services.Interfaces;
+
+namespace WingPanel.Core.Services.Implementations;
+
+public sealed class ActionCenterService : IActionCenterService
+{
+    private bool _isVisible;
+
+    public event EventHandler<bool>? VisibilityChanged;
+
+    public bool IsVisible => _isVisible;
+
+    public void Show()
+    {
+        if (!_isVisible)
+        {
+            _isVisible = true;
+            VisibilityChanged?.Invoke(this, true);
+        }
+    }
+
+    public void Hide()
+    {
+        if (_isVisible)
+        {
+            _isVisible = false;
+            VisibilityChanged?.Invoke(this, false);
+        }
+    }
+
+    public void Toggle()
+    {
+        if (_isVisible)
+        {
+            Hide();
+        }
+        else
+        {
+            Show();
+        }
+    }
+}

--- a/src/WingPanel.Core/Services/Implementations/AudioService.cs
+++ b/src/WingPanel.Core/Services/Implementations/AudioService.cs
@@ -1,0 +1,40 @@
+using System;
+using WingPanel.Core.Services.Interfaces;
+
+namespace WingPanel.Core.Services.Implementations;
+
+public sealed class AudioService : IAudioService
+{
+    private double _volume = 0.5;
+    private bool _isMuted;
+
+    public event EventHandler<double>? VolumeChanged;
+
+    public event EventHandler<bool>? MutedChanged;
+
+    public double Volume => _volume;
+
+    public bool IsMuted => _isMuted;
+
+    public void SetVolume(double value)
+    {
+        var clamped = Math.Clamp(value, 0d, 1d);
+        if (Math.Abs(clamped - _volume) > 0.0001)
+        {
+            _volume = clamped;
+            VolumeChanged?.Invoke(this, _volume);
+        }
+
+        if (_volume > 0 && _isMuted)
+        {
+            _isMuted = false;
+            MutedChanged?.Invoke(this, _isMuted);
+        }
+    }
+
+    public void ToggleMute()
+    {
+        _isMuted = !_isMuted;
+        MutedChanged?.Invoke(this, _isMuted);
+    }
+}

--- a/src/WingPanel.Core/Services/Implementations/CursorService.cs
+++ b/src/WingPanel.Core/Services/Implementations/CursorService.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Threading;
+using WingPanel.Core.Interop;
+using WingPanel.Core.Models;
+using WingPanel.Core.Services.Interfaces;
+
+namespace WingPanel.Core.Services.Implementations;
+
+public sealed class CursorService : ICursorService, IDisposable
+{
+    private readonly Timer _pollTimer;
+    private PixelPoint _lastKnown = PixelPoint.Empty;
+
+    public CursorService()
+    {
+        _pollTimer = new Timer(OnPoll, null, TimeSpan.FromMilliseconds(250), TimeSpan.FromMilliseconds(250));
+    }
+
+    public event EventHandler<PixelPoint>? CursorMoved;
+
+    public PixelPoint GetCursorPosition()
+    {
+        var point = QueryCursor();
+        _lastKnown = point;
+        return point;
+    }
+
+    public void SetCursorPosition(PixelPoint point)
+    {
+        _lastKnown = point;
+        if (OperatingSystem.IsWindows())
+        {
+            User32.SetCursorPos(point.X, point.Y);
+        }
+
+        CursorMoved?.Invoke(this, point);
+    }
+
+    private PixelPoint QueryCursor()
+    {
+        if (OperatingSystem.IsWindows() && User32.GetCursorPos(out var point))
+        {
+            return new PixelPoint(point.X, point.Y);
+        }
+
+        return _lastKnown;
+    }
+
+    private void OnPoll(object? state)
+    {
+        var point = QueryCursor();
+        if (point != _lastKnown)
+        {
+            _lastKnown = point;
+            CursorMoved?.Invoke(this, point);
+        }
+    }
+
+    public void Dispose()
+    {
+        _pollTimer.Dispose();
+    }
+}

--- a/src/WingPanel.Core/Services/Implementations/DisplayBoundsService.cs
+++ b/src/WingPanel.Core/Services/Implementations/DisplayBoundsService.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Threading;
+using WingPanel.Core.Interop;
+using WingPanel.Core.Models;
+using WingPanel.Core.Services.Interfaces;
+
+namespace WingPanel.Core.Services.Implementations;
+
+public sealed class DisplayBoundsService : IDisplayBoundsService, IDisposable
+{
+    private readonly Timer _pollTimer;
+    private DisplayBounds _current;
+
+    public DisplayBoundsService()
+    {
+        _current = QueryBounds();
+        _pollTimer = new Timer(OnPoll, null, TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(2));
+    }
+
+    public event EventHandler<DisplayBounds>? DisplayChanged;
+
+    public DisplayBounds GetPrimaryDisplay() => _current;
+
+    private DisplayBounds QueryBounds()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            var width = User32.GetSystemMetrics(User32.SM_CXSCREEN);
+            var height = User32.GetSystemMetrics(User32.SM_CYSCREEN);
+            if (width > 0 && height > 0)
+            {
+                return new DisplayBounds(0, 0, width, height);
+            }
+        }
+
+        return DisplayBounds.Default;
+    }
+
+    private void OnPoll(object? state)
+    {
+        var bounds = QueryBounds();
+        if (!bounds.Equals(_current))
+        {
+            _current = bounds;
+            DisplayChanged?.Invoke(this, bounds);
+        }
+    }
+
+    public void Dispose()
+    {
+        _pollTimer.Dispose();
+    }
+}

--- a/src/WingPanel.Core/Services/Implementations/HotkeyService.cs
+++ b/src/WingPanel.Core/Services/Implementations/HotkeyService.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
+using WingPanel.Core.Models;
+using WingPanel.Core.Services.Interfaces;
+
+namespace WingPanel.Core.Services.Implementations;
+
+public interface IHotkeyRegistrationBackend
+{
+    event EventHandler<HotkeyEventArgs>? HotkeyPressed;
+
+    bool TryRegister(string name, HotkeyBinding binding);
+
+    void Unregister(string name);
+
+    void Reset();
+}
+
+internal sealed class InMemoryHotkeyBackend : IHotkeyRegistrationBackend
+{
+    private readonly Dictionary<string, HotkeyBinding> _bindings = new(StringComparer.OrdinalIgnoreCase);
+
+    public event EventHandler<HotkeyEventArgs>? HotkeyPressed;
+
+    public IReadOnlyDictionary<string, HotkeyBinding> Registrations => _bindings;
+
+    public bool TryRegister(string name, HotkeyBinding binding)
+    {
+        _bindings[name] = binding;
+        return true;
+    }
+
+    public void Unregister(string name)
+    {
+        _bindings.Remove(name);
+    }
+
+    public void Reset()
+    {
+        _bindings.Clear();
+    }
+
+    public void Raise(string name)
+    {
+        if (_bindings.TryGetValue(name, out var binding))
+        {
+            HotkeyPressed?.Invoke(this, new HotkeyEventArgs(name, binding));
+        }
+    }
+}
+
+public sealed class HotkeyService : IHotkeyService
+{
+    private readonly IHotkeyRegistrationBackend _backend;
+    private readonly ILogService? _logger;
+    private readonly Dictionary<string, HotkeyBinding> _registrations = new(StringComparer.OrdinalIgnoreCase);
+
+    public HotkeyService(IHotkeyRegistrationBackend? backend = null, ILogService? logger = null)
+    {
+        _backend = backend ?? new InMemoryHotkeyBackend();
+        _logger = logger;
+        _backend.HotkeyPressed += OnBackendHotkeyPressed;
+    }
+
+    public event EventHandler<HotkeyEventArgs>? HotkeyPressed;
+
+    public IReadOnlyDictionary<string, HotkeyBinding> Registrations => _registrations;
+
+    public bool TryRegister(string name, HotkeyBinding binding)
+    {
+        if (TryRegisterInternal(name, binding))
+        {
+            return true;
+        }
+
+        if (binding.Modifiers.HasFlag(HotkeyModifiers.Win) && binding.Key == VirtualKey.Space)
+        {
+            var fallback = binding.WithAdditionalModifier(HotkeyModifiers.Control);
+            if (TryRegisterInternal(name, fallback))
+            {
+                _logger?.LogInformation($"Applied fallback Ctrl modifier for {name}");
+                return true;
+            }
+        }
+
+        _logger?.LogWarning($"Failed to register hotkey {name} ({binding})");
+        return false;
+    }
+
+    public void Unregister(string name)
+    {
+        if (_registrations.Remove(name))
+        {
+            _backend.Unregister(name);
+        }
+    }
+
+    public void Reset()
+    {
+        _backend.Reset();
+        _registrations.Clear();
+    }
+
+    private bool TryRegisterInternal(string name, HotkeyBinding binding)
+    {
+        if (_backend.TryRegister(name, binding))
+        {
+            _registrations[name] = binding;
+            _logger?.LogInformation($"Registered {name} => {binding}");
+            return true;
+        }
+
+        return false;
+    }
+
+    private void OnBackendHotkeyPressed(object? sender, HotkeyEventArgs e)
+    {
+        HotkeyPressed?.Invoke(this, e);
+    }
+}

--- a/src/WingPanel.Core/Services/Implementations/SettingsService.cs
+++ b/src/WingPanel.Core/Services/Implementations/SettingsService.cs
@@ -1,0 +1,113 @@
+using System;
+using System.IO;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using WingPanel.Core.Models.Settings;
+using WingPanel.Core.Services.Interfaces;
+
+namespace WingPanel.Core.Services.Implementations;
+
+public sealed class SettingsService : ISettingsService
+{
+    private static readonly JsonSerializerOptions Options = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+    };
+
+    private readonly SemaphoreSlim _semaphore = new(1, 1);
+    private readonly string _settingsPath;
+    private readonly ILogService? _logger;
+
+    public SettingsService(ILogService? logger = null, string? baseDirectory = null)
+    {
+        _logger = logger;
+        var root = baseDirectory ?? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "WingPanel");
+        Directory.CreateDirectory(root);
+        _settingsPath = Path.Combine(root, "Settings.json");
+        Current = LoadFromDisk();
+    }
+
+    public event EventHandler<WingPanelSettings>? SettingsChanged;
+
+    public WingPanelSettings Current { get; private set; }
+
+    public async Task SaveAsync(CancellationToken cancellationToken = default)
+    {
+        await _semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            var json = JsonSerializer.Serialize(Current, Options);
+            await File.WriteAllTextAsync(_settingsPath, json, cancellationToken).ConfigureAwait(false);
+            _logger?.LogInformation($"Saved settings to {_settingsPath}");
+        }
+        finally
+        {
+            _semaphore.Release();
+        }
+    }
+
+    public async Task ReloadAsync(CancellationToken cancellationToken = default)
+    {
+        await _semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            Current = LoadFromDisk();
+        }
+        finally
+        {
+            _semaphore.Release();
+        }
+
+        SettingsChanged?.Invoke(this, Current);
+    }
+
+    private WingPanelSettings LoadFromDisk()
+    {
+        try
+        {
+            if (!File.Exists(_settingsPath))
+            {
+                _logger?.LogInformation("Settings file not found; using defaults");
+                return EnsureDefaults(new WingPanelSettings());
+            }
+
+            var json = File.ReadAllText(_settingsPath);
+            if (string.IsNullOrWhiteSpace(json))
+            {
+                _logger?.LogWarning("Settings file empty; using defaults");
+                return EnsureDefaults(new WingPanelSettings());
+            }
+
+            var settings = JsonSerializer.Deserialize<WingPanelSettings>(json, Options) ?? new WingPanelSettings();
+            return EnsureDefaults(settings);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError("Failed to load settings; using defaults", ex);
+            return EnsureDefaults(new WingPanelSettings());
+        }
+    }
+
+    private static WingPanelSettings EnsureDefaults(WingPanelSettings settings)
+    {
+        settings.Layout ??= RegionLayoutSettings.CreateDefault();
+        settings.Launcher ??= new LauncherSettings();
+        settings.Volume ??= new VolumeSettings();
+        settings.TaskSwitcher ??= new TaskSwitcherSettings();
+        settings.Notifications ??= new NotificationSettings();
+        if (settings.Version < WingPanelSettings.CurrentVersion)
+        {
+            if (settings.Layout.OrderedRegions.Count == 0)
+            {
+                settings.Layout = RegionLayoutSettings.CreateDefault();
+            }
+
+            settings.Version = WingPanelSettings.CurrentVersion;
+        }
+
+        return settings;
+    }
+}

--- a/src/WingPanel.Core/Services/Implementations/WindowEnumService.cs
+++ b/src/WingPanel.Core/Services/Implementations/WindowEnumService.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using WingPanel.Core.Models;
+using WingPanel.Core.Services.Interfaces;
+using WingPanel.Core.Utilities;
+
+namespace WingPanel.Core.Services.Implementations;
+
+public interface IWindowEnumerationBackend
+{
+    IEnumerable<WindowInfo> EnumerateWindows();
+}
+
+internal sealed class DefaultWindowEnumerationBackend : IWindowEnumerationBackend
+{
+    public IEnumerable<WindowInfo> EnumerateWindows()
+    {
+        yield break;
+    }
+}
+
+public sealed class WindowEnumService : IWindowEnumService
+{
+    private readonly IWindowEnumerationBackend _backend;
+    private readonly MruList<WindowInfo> _mru = new(new WindowInfoHandleComparer());
+    private List<WindowInfo> _current = new();
+
+    public WindowEnumService(IWindowEnumerationBackend? backend = null)
+    {
+        _backend = backend ?? new DefaultWindowEnumerationBackend();
+        Refresh();
+    }
+
+    public event EventHandler<IReadOnlyList<WindowInfo>>? WindowsChanged;
+
+    public IReadOnlyList<WindowInfo> CurrentWindows => _current;
+
+    public void Refresh()
+    {
+        var enumerated = _backend.EnumerateWindows().Where(w => w.IsVisible).ToList();
+        foreach (var window in enumerated)
+        {
+            _mru.Touch(window);
+        }
+
+        Rebuild(enumerated, raiseEvent: true);
+    }
+
+    public void NotifyActivated(WindowInfo window)
+    {
+        var activated = window.WithActivatedNow();
+        _mru.Touch(activated);
+        Rebuild(null, raiseEvent: true);
+    }
+
+    private void Rebuild(IReadOnlyCollection<WindowInfo>? enumerated, bool raiseEvent)
+    {
+        var source = enumerated?.ToDictionary(w => w.Handle) ?? _current.ToDictionary(w => w.Handle);
+        var ordered = new List<WindowInfo>();
+
+        foreach (var item in _mru)
+        {
+            if (source.TryGetValue(item.Handle, out var existing))
+            {
+                ordered.Add(existing with { LastActivatedUtc = item.LastActivatedUtc });
+            }
+        }
+
+        if (enumerated is not null)
+        {
+            foreach (var window in enumerated)
+            {
+                if (!ordered.Any(w => w.Handle == window.Handle))
+                {
+                    ordered.Add(window);
+                }
+            }
+        }
+
+        _current = ordered;
+
+        if (raiseEvent)
+        {
+            WindowsChanged?.Invoke(this, _current);
+        }
+    }
+}

--- a/src/WingPanel.Core/Services/Interfaces/IActionCenterService.cs
+++ b/src/WingPanel.Core/Services/Interfaces/IActionCenterService.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace WingPanel.Core.Services.Interfaces;
+
+public interface IActionCenterService
+{
+    event EventHandler<bool>? VisibilityChanged;
+
+    bool IsVisible { get; }
+
+    void Show();
+
+    void Hide();
+
+    void Toggle();
+}

--- a/src/WingPanel.Core/Services/Interfaces/IAudioService.cs
+++ b/src/WingPanel.Core/Services/Interfaces/IAudioService.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace WingPanel.Core.Services.Interfaces;
+
+public interface IAudioService
+{
+    event EventHandler<double>? VolumeChanged;
+
+    event EventHandler<bool>? MutedChanged;
+
+    double Volume { get; }
+
+    bool IsMuted { get; }
+
+    void SetVolume(double value);
+
+    void ToggleMute();
+}

--- a/src/WingPanel.Core/Services/Interfaces/ICursorService.cs
+++ b/src/WingPanel.Core/Services/Interfaces/ICursorService.cs
@@ -1,0 +1,13 @@
+using System;
+using WingPanel.Core.Models;
+
+namespace WingPanel.Core.Services.Interfaces;
+
+public interface ICursorService
+{
+    event EventHandler<PixelPoint>? CursorMoved;
+
+    PixelPoint GetCursorPosition();
+
+    void SetCursorPosition(PixelPoint point);
+}

--- a/src/WingPanel.Core/Services/Interfaces/IDisplayBoundsService.cs
+++ b/src/WingPanel.Core/Services/Interfaces/IDisplayBoundsService.cs
@@ -1,0 +1,11 @@
+using System;
+using WingPanel.Core.Models;
+
+namespace WingPanel.Core.Services.Interfaces;
+
+public interface IDisplayBoundsService
+{
+    event EventHandler<DisplayBounds>? DisplayChanged;
+
+    DisplayBounds GetPrimaryDisplay();
+}

--- a/src/WingPanel.Core/Services/Interfaces/IHotkeyService.cs
+++ b/src/WingPanel.Core/Services/Interfaces/IHotkeyService.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Collections.Generic;
+using WingPanel.Core.Models;
+
+namespace WingPanel.Core.Services.Interfaces;
+
+public interface IHotkeyService
+{
+    event EventHandler<HotkeyEventArgs>? HotkeyPressed;
+
+    IReadOnlyDictionary<string, HotkeyBinding> Registrations { get; }
+
+    bool TryRegister(string name, HotkeyBinding binding);
+
+    void Unregister(string name);
+
+    void Reset();
+}

--- a/src/WingPanel.Core/Services/Interfaces/ILogService.cs
+++ b/src/WingPanel.Core/Services/Interfaces/ILogService.cs
@@ -1,0 +1,15 @@
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace WingPanel.Core.Services.Interfaces;
+
+public interface ILogService
+{
+    void Log(LogLevel level, string message, Exception? exception = null);
+
+    void LogInformation(string message) => Log(LogLevel.Information, message);
+
+    void LogWarning(string message) => Log(LogLevel.Warning, message);
+
+    void LogError(string message, Exception? exception = null) => Log(LogLevel.Error, message, exception);
+}

--- a/src/WingPanel.Core/Services/Interfaces/ISettingsService.cs
+++ b/src/WingPanel.Core/Services/Interfaces/ISettingsService.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using WingPanel.Core.Models.Settings;
+
+namespace WingPanel.Core.Services.Interfaces;
+
+public interface ISettingsService
+{
+    event EventHandler<WingPanelSettings>? SettingsChanged;
+
+    WingPanelSettings Current { get; }
+
+    Task SaveAsync(CancellationToken cancellationToken = default);
+
+    Task ReloadAsync(CancellationToken cancellationToken = default);
+}

--- a/src/WingPanel.Core/Services/Interfaces/IWindowEnumService.cs
+++ b/src/WingPanel.Core/Services/Interfaces/IWindowEnumService.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Collections.Generic;
+using WingPanel.Core.Models;
+
+namespace WingPanel.Core.Services.Interfaces;
+
+public interface IWindowEnumService
+{
+    event EventHandler<IReadOnlyList<WindowInfo>>? WindowsChanged;
+
+    IReadOnlyList<WindowInfo> CurrentWindows { get; }
+
+    void Refresh();
+
+    void NotifyActivated(WindowInfo window);
+}

--- a/src/WingPanel.Core/Utilities/MruList.cs
+++ b/src/WingPanel.Core/Utilities/MruList.cs
@@ -1,0 +1,56 @@
+using System.Collections;
+using System.Collections.Generic;
+
+namespace WingPanel.Core.Utilities;
+
+public sealed class MruList<T> : IEnumerable<T>
+{
+    private readonly LinkedList<T> _items = new();
+    private readonly IEqualityComparer<T> _comparer;
+
+    public MruList()
+        : this(EqualityComparer<T>.Default)
+    {
+    }
+
+    public MruList(IEqualityComparer<T> comparer)
+    {
+        _comparer = comparer;
+    }
+
+    public int Count => _items.Count;
+
+    public void Touch(T item)
+    {
+        var node = FindNode(item);
+        if (node is not null)
+        {
+            node.Value = item;
+            _items.Remove(node);
+            _items.AddFirst(node);
+        }
+        else
+        {
+            _items.AddFirst(item);
+        }
+    }
+
+    public IReadOnlyList<T> ToSnapshot() => new List<T>(_items);
+
+    private LinkedListNode<T>? FindNode(T item)
+    {
+        for (var node = _items.First; node is not null; node = node.Next)
+        {
+            if (_comparer.Equals(node.Value, item))
+            {
+                return node;
+            }
+        }
+
+        return null;
+    }
+
+    public IEnumerator<T> GetEnumerator() => _items.GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}

--- a/src/WingPanel.Core/Utilities/WindowInfoHandleComparer.cs
+++ b/src/WingPanel.Core/Utilities/WindowInfoHandleComparer.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+using WingPanel.Core.Models;
+
+namespace WingPanel.Core.Utilities;
+
+public sealed class WindowInfoHandleComparer : IEqualityComparer<WindowInfo>
+{
+    public bool Equals(WindowInfo? x, WindowInfo? y)
+    {
+        if (ReferenceEquals(x, y))
+        {
+            return true;
+        }
+
+        if (x is null || y is null)
+        {
+            return false;
+        }
+
+        return x.Handle == y.Handle;
+    }
+
+    public int GetHashCode(WindowInfo obj) => obj.Handle.GetHashCode();
+}

--- a/src/WingPanel.Core/WingPanel.Core.csproj
+++ b/src/WingPanel.Core/WingPanel.Core.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net8.0-windows10.0.19041.0</TargetFrameworks>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+    <PackageReference Include="System.Text.Json" Version="8.0.4" />
+  </ItemGroup>
+</Project>

--- a/src/WingPanel.Tests/HotkeyServiceTests.cs
+++ b/src/WingPanel.Tests/HotkeyServiceTests.cs
@@ -1,0 +1,83 @@
+using System.Collections.Generic;
+using WingPanel.Core.Models;
+using WingPanel.Core.Services.Implementations;
+using WingPanel.Core.Services.Interfaces;
+using Xunit;
+
+namespace WingPanel.Tests;
+
+public class HotkeyServiceTests
+{
+    [Fact]
+    public void Register_WinSpaceFallsBackToCtrlWinSpace()
+    {
+        var backend = new RejectingBackend();
+        var service = new HotkeyService(backend, new NoOpLogService());
+        var success = service.TryRegister("Toggle", new HotkeyBinding(HotkeyModifiers.Win, VirtualKey.Space));
+
+        Assert.True(success);
+        Assert.True(service.Registrations.TryGetValue("Toggle", out var registered));
+        Assert.Equal(HotkeyModifiers.Win | HotkeyModifiers.Control, registered.Modifiers);
+        Assert.Equal(VirtualKey.Space, registered.Key);
+        Assert.Equal("Toggle", backend.LastRegisteredId);
+        Assert.Equal(registered, backend.LastRegisteredBinding);
+    }
+
+    [Fact]
+    public void Register_CustomHotkeySuccess()
+    {
+        var backend = new RejectingBackend();
+        backend.Allowed.Add(new HotkeyBinding(HotkeyModifiers.Control | HotkeyModifiers.Shift, VirtualKey.A));
+        var service = new HotkeyService(backend, new NoOpLogService());
+
+        Assert.True(service.TryRegister("Custom", new HotkeyBinding(HotkeyModifiers.Control | HotkeyModifiers.Shift, VirtualKey.A)));
+        Assert.Equal(HotkeyModifiers.Control | HotkeyModifiers.Shift, service.Registrations["Custom"].Modifiers);
+    }
+
+    private sealed class RejectingBackend : IHotkeyRegistrationBackend
+    {
+        public HashSet<HotkeyBinding> Allowed { get; } = new();
+
+        public HotkeyBinding? LastRegisteredBinding { get; private set; }
+
+        public string? LastRegisteredId { get; private set; }
+
+        public event EventHandler<HotkeyEventArgs>? HotkeyPressed;
+
+        public bool TryRegister(string name, HotkeyBinding binding)
+        {
+            if (Allowed.Contains(binding))
+            {
+                LastRegisteredId = name;
+                LastRegisteredBinding = binding;
+                return true;
+            }
+
+            if (binding.Modifiers.HasFlag(HotkeyModifiers.Control) && binding.Modifiers.HasFlag(HotkeyModifiers.Win) && binding.Key == VirtualKey.Space)
+            {
+                Allowed.Add(binding);
+                LastRegisteredId = name;
+                LastRegisteredBinding = binding;
+                return true;
+            }
+
+            return false;
+        }
+
+        public void Unregister(string name)
+        {
+        }
+
+        public void Reset()
+        {
+            Allowed.Clear();
+        }
+    }
+
+    private sealed class NoOpLogService : ILogService
+    {
+        public void Log(Microsoft.Extensions.Logging.LogLevel level, string message, Exception? exception = null)
+        {
+        }
+    }
+}

--- a/src/WingPanel.Tests/SettingsServiceTests.cs
+++ b/src/WingPanel.Tests/SettingsServiceTests.cs
@@ -1,0 +1,60 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using WingPanel.Core.Models.Settings;
+using WingPanel.Core.Services.Implementations;
+using WingPanel.Core.Services.Interfaces;
+using Xunit;
+
+namespace WingPanel.Tests;
+
+public sealed class SettingsServiceTests : IDisposable
+{
+    private readonly string _baseDirectory;
+
+    public SettingsServiceTests()
+    {
+        _baseDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(_baseDirectory);
+    }
+
+    [Fact]
+    public async Task SaveAndReload_PreservesChanges()
+    {
+        var service = new SettingsService(new TestLogService(), _baseDirectory);
+        service.Current.Launcher.MaxFrequentApps = 12;
+        await service.SaveAsync();
+
+        service.Current.Launcher.MaxFrequentApps = 1;
+        await service.ReloadAsync();
+
+        Assert.Equal(12, service.Current.Launcher.MaxFrequentApps);
+    }
+
+    [Fact]
+    public void Load_MigratesOlderVersion()
+    {
+        var json = "{\"version\":1,\"launcher\":{\"showFrequentApps\":true,\"maxFrequentApps\":4}}";
+        File.WriteAllText(Path.Combine(_baseDirectory, "Settings.json"), json);
+
+        var service = new SettingsService(new TestLogService(), _baseDirectory);
+
+        Assert.Equal(WingPanelSettings.CurrentVersion, service.Current.Version);
+        Assert.NotEmpty(service.Current.Layout.OrderedRegions);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_baseDirectory))
+        {
+            Directory.Delete(_baseDirectory, recursive: true);
+        }
+    }
+
+    private sealed class TestLogService : ILogService
+    {
+        public void Log(Microsoft.Extensions.Logging.LogLevel level, string message, Exception? exception = null)
+        {
+        }
+    }
+}

--- a/src/WingPanel.Tests/WindowEnumServiceTests.cs
+++ b/src/WingPanel.Tests/WindowEnumServiceTests.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using WingPanel.Core.Models;
+using WingPanel.Core.Services.Implementations;
+using Xunit;
+
+namespace WingPanel.Tests;
+
+public class WindowEnumServiceTests
+{
+    [Fact]
+    public void Refresh_OrdersByMru()
+    {
+        var backend = new FakeWindowBackend(
+            new WindowInfo(1, "First", true),
+            new WindowInfo(2, "Second", true),
+            new WindowInfo(3, "Third", true));
+        var service = new WindowEnumService(backend);
+
+        Assert.Equal(new[] { 1, 2, 3 }, service.CurrentWindows.Select(w => (int)w.Handle));
+
+        service.NotifyActivated(new WindowInfo(2, "Second", true));
+
+        Assert.Equal(new[] { 2, 1, 3 }, service.CurrentWindows.Select(w => (int)w.Handle));
+    }
+
+    [Fact]
+    public void Refresh_AddsNewWindowsToEnd()
+    {
+        var backend = new FakeWindowBackend(
+            new WindowInfo(1, "First", true),
+            new WindowInfo(2, "Second", true));
+        var service = new WindowEnumService(backend);
+
+        backend.SetWindows(new WindowInfo(1, "First", true), new WindowInfo(2, "Second", true), new WindowInfo(3, "Third", true));
+        service.Refresh();
+
+        Assert.Equal(new[] { 1, 2, 3 }, service.CurrentWindows.Select(w => (int)w.Handle));
+    }
+
+    private sealed class FakeWindowBackend : IWindowEnumerationBackend
+    {
+        private IReadOnlyList<WindowInfo> _windows;
+
+        public FakeWindowBackend(params WindowInfo[] windows)
+        {
+            _windows = windows;
+        }
+
+        public IEnumerable<WindowInfo> EnumerateWindows() => _windows;
+
+        public void SetWindows(params WindowInfo[] windows) => _windows = windows;
+    }
+}

--- a/src/WingPanel.Tests/WingPanel.Tests.csproj
+++ b/src/WingPanel.Tests/WingPanel.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit" Version="2.6.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6" />
+    <ProjectReference Include="..\\WingPanel.Core\\WingPanel.Core.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- add WingPanel.sln with WinUI front-end, shared core library, and xUnit tests
- implement WinUI panel window with launcher, task switcher, volume, and notifications regions wired to core services
- build core services for hotkeys, settings, MRU window tracking, logging, and persistence
- author unit tests covering settings migration, hotkey fallback logic, and MRU ordering
- document build, packaging, and debugging steps for the new solution

## Testing
- `dotnet test src/WingPanel.Tests/WingPanel.Tests.csproj` *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ceb9abfc0c8333a40bc75084b77d2e